### PR TITLE
Add Payload property in the Video Model

### DIFF
--- a/src/Model/Video.php
+++ b/src/Model/Video.php
@@ -22,6 +22,8 @@ class Video extends AbstractMedium
 
     private $sourceUrl;
 
+    private $payload;
+
     public function getOriginalFilename() {
         return $this->originalFilename;
     }
@@ -36,5 +38,13 @@ class Video extends AbstractMedium
 
     public function setSourceUrl($sourceUrl) {
         $this->sourceUrl = $sourceUrl;
+    }
+
+    public function getPayload() {
+        return $this->payload;
+    }
+
+    public function setPayload($payload) {
+        $this->payload = $payload;
     }
 }


### PR DESCRIPTION
Actually the Video Model don't have the `payload`property. The issue is  when we want to transform a Json response with the `payload` attribute to a Video object. An error is raise by the Normalizer who doesn't find the setter
