### PR TITLE
even Composer should be executed without xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,12 @@ matrix:
     - php: hhvm
 
 before_install:
+  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:"$SYMFONY_VERSION"; fi
 
 install:
   - if [ "$deps" = "" ]; then composer install; fi
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
-
-before_script:
-  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
 
 script:
   - if [ "$COVERAGE" = "yes" ]; then phpunit --coverage-clover=coverage.clover; else phpunit; fi


### PR DESCRIPTION
The changes in #10 are not good enough. Even Composer operations should
be performed without Xdebug being enabled.