### PR TITLE
Avoid relying on the default php.ini argument separator

### DIFF
--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -144,7 +144,7 @@ class HttpClient implements HttpClientInterface
 
         // append request parameters to the URL
         if ('GET' === $method || 'DELETE' === $method) {
-            $path .= '?'.http_build_query($params);
+            $path .= '?'.http_build_query($params, '', '&');
         }
 
         // prepare the request

--- a/src/Signer/PandaSigner.php
+++ b/src/Signer/PandaSigner.php
@@ -120,7 +120,7 @@ class PandaSigner
         $canonicalQueryString = str_replace(
             array('+', '%5B', '%5D'),
             array('%20', '[', ']'),
-            http_build_query($params)
+            http_build_query($params, '', '&')
         );
         $stringToSign = sprintf(
             "%s\n%s\n%s\n%s",


### PR DESCRIPTION
Changing the default separator to something else than ``&`` in the php.ini is probably not that common, but it is possible. As this is a shared library, it cannot rely on the php.ini not being modified. So passing the separator explicitly is better.