### PR TITLE
Implement an HTTP client based on Httplug rather than Guzzle 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The recommended way to install the Panda client is using
 1. Add ``xabbuh/panda-client`` as a dependency of your project:
 
     ```bash
-    $ composer require xabbuh/panda-client "~1.0"
+    $ composer require xabbuh/panda-client php-http/guzzle6-adapter
     ```
 
 1. And require Composer's autoloader:
@@ -33,6 +33,10 @@ The recommended way to install the Panda client is using
    ``` php
    require __DIR__.'/vendor/autoload.php';
    ```
+   
+Note: The Panda client relies on [HTTPlug](http://httplug.io/) to perform HTTP requests.
+So you will need to install a client implementation to use the PandaClient. The command above
+uses the Guzzle 6 adapter, but you can use any implementation.
 
 Usage
 -----

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,17 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "guzzle/guzzle": "~3.7",
+        "php-http/client-implementation": "^1.0",
+        "php-http/discovery": "^1.2.1",
+        "php-http/httplug": "^1.1",
+        "php-http/message": "^1.5",
         "symfony/http-foundation": "~2.2|~3.0",
         "symfony/serializer": "~2.2|~3.0"
     },
     "require-dev": {
+        "guzzle/guzzle": "~3.7",
+        "guzzlehttp/psr7": "^1.4",
+        "php-http/mock-client": "^1.0",
         "symfony/phpunit-bridge": "~3.3"
     },
     "minimum-stability": "dev",

--- a/src/Api.php
+++ b/src/Api.php
@@ -11,12 +11,11 @@
 
 namespace Xabbuh\PandaClient;
 
-use Guzzle\Http\Client;
 use Xabbuh\PandaClient\Api\Account;
 use Xabbuh\PandaClient\Api\AccountManager;
 use Xabbuh\PandaClient\Api\Cloud;
 use Xabbuh\PandaClient\Api\CloudManager;
-use Xabbuh\PandaClient\Api\HttpClient;
+use Xabbuh\PandaClient\Api\HttplugClient;
 use Xabbuh\PandaClient\Serializer\Symfony\Serializer;
 use Xabbuh\PandaClient\Transformer\CloudTransformer;
 use Xabbuh\PandaClient\Transformer\EncodingTransformer;
@@ -54,11 +53,9 @@ class Api extends AbstractApi
      */
     protected function createHttpClient(Account $account, $cloudId)
     {
-        $guzzleClient = new Client('https://'.$account->getApiHost().'/v2');
-        $httpClient = new HttpClient();
+        $httpClient = new HttplugClient();
         $httpClient->setAccount($account);
         $httpClient->setCloudId($cloudId);
-        $httpClient->setGuzzleClient($guzzleClient);
 
         return $httpClient;
     }

--- a/tests/Api/HttpClientTest.php
+++ b/tests/Api/HttpClientTest.php
@@ -17,6 +17,8 @@ use Xabbuh\PandaClient\Api\HttpClient;
 
 /**
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * @group legacy
  */
 class HttpClientTest extends TestCase
 {

--- a/tests/Api/HttplugClientTest.php
+++ b/tests/Api/HttplugClientTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the XabbuhPandaClient package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\PandaClient\Tests\Api;
+
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Mock\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Xabbuh\PandaClient\Api\Account;
+use Xabbuh\PandaClient\Api\HttplugClient;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class HttplugClientTest extends TestCase
+{
+    /**
+     * @var HttplugClient
+     */
+    private $httpClient;
+
+    /**
+     * @var Client
+     */
+    private $mockClient;
+
+    protected function setUp()
+    {
+        $this->mockClient = new Client();
+        $this->httpClient = new HttplugClient($this->mockClient);
+        $this->httpClient->setAccount(new Account(
+            md5(uniqid()),
+            md5(uniqid()),
+            'api.pandastream.com'
+        ));
+        $this->httpClient->setCloudId(md5(uniqid()));
+    }
+
+    public function testGet()
+    {
+        $this->configureMockResponse(200, 'test');
+
+        $response = $this->httpClient->get('/foo');
+
+        $this->assertSame('test', $response);
+        $this->assertRequestMethod('GET');
+    }
+
+    public function testDelete()
+    {
+        $this->configureMockResponse(200, 'deleted');
+
+        $response = $this->httpClient->delete('/foo');
+
+        $this->assertSame('deleted', $response);
+        $this->assertRequestMethod('DELETE');
+    }
+
+    public function testPost()
+    {
+        $this->configureMockResponse(200, 'test');
+
+        $response = $this->httpClient->post('/foo');
+
+        $this->assertSame('test', $response);
+        $this->assertRequestMethod('POST');
+    }
+
+    public function testPut()
+    {
+        $this->configureMockResponse(200, 'test');
+
+        $response = $this->httpClient->put('/foo');
+
+        $this->assertSame('test', $response);
+        $this->assertRequestMethod('PUT');
+    }
+
+    /**
+     * @expectedException \Xabbuh\PandaClient\Exception\ApiException
+     * @expectedExceptionCode 208
+     */
+    public function testApiException()
+    {
+        $error = new \stdClass();
+        $error->error = 500;
+        $error->message = 'error message';
+        $this->configureMockResponse(208, json_encode($error));
+
+        $this->httpClient->get('/foo');
+    }
+
+    private function configureMockResponse($statusCode = 200, $responseBody = '')
+    {
+        $response = MessageFactoryDiscovery::find()->createResponse($statusCode, null, array(), $responseBody);
+
+        $this->mockClient->addResponse($response);
+    }
+
+    private function assertRequestMethod($expectedMethod)
+    {
+        /** @var RequestInterface[] $requests */
+        $requests = $this->mockClient->getRequests();
+
+        $this->assertCount(1, $requests, '1 request has been sent');
+        $this->assertSame($expectedMethod, $requests[0]->getMethod());
+    }
+}

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -11,11 +11,17 @@
 
 namespace Xabbuh\PandaClient\Tests;
 
+use Http\Discovery\HttpClientDiscovery;
 use PHPUnit\Framework\TestCase;
 use Xabbuh\PandaClient\Api;
 
 class ApiTest extends TestCase
 {
+    protected function setUp()
+    {
+        HttpClientDiscovery::prependStrategy('Http\Discovery\Strategy\MockClientStrategy');
+    }
+
     public function testDefaultApi()
     {
         $accessKey = md5(uniqid());


### PR DESCRIPTION
People wanting to upgrade to the new version will need to require a HTTPlug client implementation. Otherwise, Composer will reject the update (if you update the requirement in your composer.json, composer will fail saying it cannot find an implementation for the virtual package. If you don't bump the min version, it will use the older version of panda-client).

Once you have it, there is no change for people using the `Api` class, as it creates the client internally. It will use the new `HttplugClient`.

For people instantiating the Cloud themselves (hint: PandaBundle), the old Guzzle 3 client is still there, but deprecated. However, Guzzle 3 is not installed automatically anymore. Projects using the client will need to require `guzzle/guzzle` themselves or switch to the new HttplugClient. This is a small BC break currently (unfortunately, it may affect the bundle).

Unfortunately, the only way to be fully BC would be to keep the Guzzle 3 requirement, as this is where the BC break occurs: the legacy HTTP client depends on Guzzle 3 but we don't require it anymore. And I don't want to keep the requirement as Guzzle 3 is abandoned and incompatible with Symfony 3.
Fortunately, if your project does not already use HTTPlug, Composer will not update to the new version of panda client automatically (as you need to select a client implementation). So we may document it in the release notes.

Closes #6