### PR TITLE
Add support for HTTPlug 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^5.6 || ^7.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.2.1",
-        "php-http/httplug": "^1.1",
+        "php-http/httplug": "^1.1 || ^2.0",
         "php-http/message": "^1.5",
         "symfony/http-foundation": "~2.2|~3.0|~4.0",
         "symfony/serializer": "~2.2|~3.0|~4.0"


### PR DESCRIPTION
Version 2 has no BC break for users of the library (but requires PHP 7+). The only BC breaks are for libraries implementing the client interface (due to the added return type).