### PR TITLE
Install PHPUnit during the install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 
 install:
   - composer update $COMPOSER_OPTIONS
+  - vendor/bin/simple-phpunit install
 
 script:
   - if [ "$COVERAGE" = "yes" ]; then vendor/bin/simple-phpunit --coverage-clover=coverage.clover; else vendor/bin/simple-phpunit; fi


### PR DESCRIPTION
The simple-phpunit bridge is able to install the necessary PHPUnit  when necessary. But triggering the installation during the install phase makes the output nicer as it will get collapsed instead of being visible near the test run.