### PR TITLE
Improve the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,16 @@ matrix:
       env: SYMFONY_VERSION="2.7.x"
     - php: 7.0
       env: SYMFONY_VERSION="2.8.x"
+    - php: 7.1
+      env: SYMFONY_VERSION="3.4.x"
     - php: 7.0
     - php: 7.1
+    - php: 7.2
+    - php: 7.3
       env: COVERAGE=yes COMPOSER_OPTIONS=""
 
 before_install:
-  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
+  - if [ "$COVERAGE" != "yes" ]; then phpenv config-rm xdebug.ini; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:"$SYMFONY_VERSION"; fi
 
 install:


### PR DESCRIPTION
- add testing on PHP 7.2 and 7.3
- add testing against the Symfony 3.4 LTS
- remove remaining references to HHVM